### PR TITLE
Fix optimizer step indentation under sync_gradients

### DIFF
--- a/scripts/train_wan2_1.py
+++ b/scripts/train_wan2_1.py
@@ -986,8 +986,8 @@ def main(_):
                             accelerator.clip_grad_norm_(
                                 transformer.parameters(), config.train.max_grad_norm
                             )
-                        optimizer.step()
-                        optimizer.zero_grad()
+                            optimizer.step()
+                            optimizer.zero_grad()
 
                     # Checks if the accelerator has performed an optimization step behind the scenes
                     if accelerator.sync_gradients:


### PR DESCRIPTION
## Summary
- move `optimizer.step()` and `optimizer.zero_grad()` inside `if accelerator.sync_gradients:` in `scripts/train_wan2_1.py`
- ensures optimizer updates only occur when gradients are synchronized

## Testing
- not run (indentation-only control-flow fix)
